### PR TITLE
Possibility to add some tags so you can easily identify resources in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For an example of using ALB with ECS look no further than the [hashicorp example
 * `principle_account_id` - A mapping of regions to principle account IDs used to send LB logs. (Should only change as regions are added)
 * `subnets` - ALB will be created in the subnets in this list. (Required)
 * `vpc_id` - Resources will be created in the VPC with this `id`. (Required)
+* `tags` - A mapping of tags to assign to the resource.
 
 ## Outputs
 * `alb_id` - `id` of the ALB created.
@@ -62,6 +63,11 @@ module "alb" {
   log_prefix          = "${var.log_prefix}"
   subnets             = "${var.public_subnets}"
   vpc_id              = "${var.vpc_id}"
+
+  tags {
+      "Terraform" = "true"
+      "Env" = "${terraform.env}"
+  }
 }
 ```
 3. Always `terraform plan` to see your change before running `terraform apply`.

--- a/alb/main.tf
+++ b/alb/main.tf
@@ -24,12 +24,16 @@ resource "aws_alb" "main" {
     bucket = "${var.log_bucket}"
     prefix = "${var.log_prefix}"
   }
+
+  tags = "${merge(var.tags, map("Name", format("%s", var.alb_name)))}"
 }
 
 resource "aws_s3_bucket" "log_bucket" {
   bucket        = "${var.log_bucket}"
   policy        = "${data.template_file.bucket_policy.rendered}"
   force_destroy = true
+
+  tags = "${merge(var.tags, map("Name", format("%s", var.log_bucket)))}"
 }
 
 resource "aws_alb_target_group" "target_group" {
@@ -53,6 +57,8 @@ resource "aws_alb_target_group" "target_group" {
     cookie_duration = "${var.cookie_duration}"
     enabled         = "${ var.cookie_duration == 1 ? false : true}"
   }
+
+  tags = "${merge(var.tags, map("Name", format("%s-tg", var.alb_name)))}"
 }
 
 resource "aws_alb_listener" "front_end_http" {

--- a/alb/variables.tf
+++ b/alb/variables.tf
@@ -93,3 +93,8 @@ variable "subnets" {
 variable "vpc_id" {
   description = "VPC id where the ALB and other resources will be deployed."
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  default     = {}
+}


### PR DESCRIPTION
Possibility to add some tags so you can easily identify resources in AWS. 
It might be also needed for a kill script.

Usage:
tags {
    "Name" = "${var.service_name}"
    "Terraform" = "true"
  }